### PR TITLE
Поправил транскрипцию Лесиньского

### DIFF
--- a/names.md
+++ b/names.md
@@ -204,7 +204,7 @@
 
 ### Lesiński, Kornel
 
-**Лесински, Корнель** — [kornel.ski](https://kornel.ski/), [@kornelski](https://twitter.com/kornelski)
+**Лесиньский, Корнель** — [kornel.ski](https://kornel.ski/), [@kornelski](https://twitter.com/kornelski)
 
 ### Lewis, Paul
 


### PR DESCRIPTION
Мягкая н в польском. Окончание -ski традиционно распознаётся как русское -ский. Так удобнее склонять (поляки тоже склоняют свои фамилии, да и чужие).